### PR TITLE
Removed dataType property

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -26,7 +26,6 @@ var postItem = function (message) {
   $.ajax({
     type: "PUT",
     url: uploadPath,
-    dataType: 'json',
     contentType: 'application/json',
     async: false,
     headers: {'x-amz-acl': 'bucket-owner-full-control'},


### PR DESCRIPTION
dataType property is used when expecting data from the server. This fixes the "parseerror" message and the "Unexpected End of Input" error. Success callback now working.
